### PR TITLE
Query all child accounts in RetrieveRequests (Gets)

### DIFF
--- a/FuelSDK-CSharp/GetReturn.cs
+++ b/FuelSDK-CSharp/GetReturn.cs
@@ -39,7 +39,8 @@ namespace FuelSDK
             var response = ExecuteAPI(x =>
             {
                 var rr = new RetrieveRequest();
-
+                rr.QueryAllAccounts = true;
+                
                 // Handle RetrieveAllSinceLastBatch
                 if (x.GetType().GetProperty("GetSinceLastBatch") != null)
                     rr.RetrieveAllSinceLastBatch = (bool)x.GetType().GetProperty("GetSinceLastBatch").GetValue(x, null);


### PR DESCRIPTION
DO NOT MERGE this back into the original repo. Instead, there should be a better solution for passing around all of these option flags since there are a TON of SOAP params not supported by the library.